### PR TITLE
Pass in an existing changelog file and add the new entry to it

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -8,19 +8,21 @@ import (
 
 	"github.com/ammar-ahmed22/chlog/ai"
 	"github.com/ammar-ahmed22/chlog/git"
+	"github.com/ammar-ahmed22/chlog/models"
 	"github.com/ammar-ahmed22/chlog/utils"
 	"github.com/spf13/cobra"
 )
 
 type generateFlags struct {
-	From     string
-	To       string
-	Verbose  bool
-	Provider string
-	Model    string
-	Date     string
-	APIKey   string
-	Pretty   bool
+	From              string
+	To                string
+	Verbose           bool
+	Provider          string
+	Model             string
+	Date              string
+	APIKey            string
+	Pretty            bool
+	ExistingChangelog []models.ChangelogEntry
 }
 
 func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
@@ -100,15 +102,29 @@ func parseGenerateFlags(cmd *cobra.Command) (*generateFlags, error) {
 		return nil, err
 	}
 
+	file, err := cmd.Flags().GetString("file")
+	if err != nil {
+		return nil, err
+	}
+
+	var existingChangelog []models.ChangelogEntry
+	if file != "" {
+		existingChangelog, err = utils.ParseAndValidateChangelogFile(file)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &generateFlags{
-		From:     from,
-		To:       to,
-		Verbose:  verbose,
-		Provider: provider,
-		Model:    model,
-		Date:     date,
-		APIKey:   apiKey,
-		Pretty:   pretty,
+		From:              from,
+		To:                to,
+		Verbose:           verbose,
+		Provider:          provider,
+		Model:             model,
+		Date:              date,
+		APIKey:            apiKey,
+		Pretty:            pretty,
+		ExistingChangelog: existingChangelog,
 	}, nil
 }
 
@@ -200,4 +216,5 @@ func init() {
 	generateCmd.Flags().String("apiKey", "", "API key for the LLM provider (can also be set via environment variable, see chlog models for details)")
 	generateCmd.Flags().StringP("date", "d", time.Now().Format("2006-01-02"), "Date for the changelog entry in YYYY-MM-DD format")
 	generateCmd.Flags().Bool("pretty", false, "Prettified JSON output")
+	generateCmd.Flags().String("file", "", "Path to existing changelog JSON file to update with the new entry (should be an array of changelog entries or empty file)")
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/ammar-ahmed22/chlog/models"
 )
 
 func Eprintln(args ...any) {
@@ -11,4 +14,27 @@ func Eprintln(args ...any) {
 
 func Eprintf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, format, args...)
+}
+
+func ParseAndValidateChangelogFile(path string) ([]models.ChangelogEntry, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("File '%s' does not exist", path)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading file '%s': %v", path, err)
+	}
+
+	if len(contents) == 0 {
+		return []models.ChangelogEntry{}, nil
+	}
+
+	var changelog []models.ChangelogEntry
+	err = json.Unmarshal(contents, &changelog)
+	if err != nil {
+		return nil, fmt.Errorf("Changelog file '%s' is not valid JSON. See https://github.com/ammar-ahmed22/chlog#changelog-format for the expected format", path)
+	}
+
+	return changelog, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -38,3 +38,15 @@ func ParseAndValidateChangelogFile(path string) ([]models.ChangelogEntry, error)
 
 	return changelog, nil
 }
+
+func WriteChangelogFile(path string, changelog []models.ChangelogEntry) error {
+	contents, err := json.MarshalIndent(changelog, "", "  ")
+	if err != nil {
+		return fmt.Errorf("Error marshalling changelog to JSON: %v", err)
+	}
+	err = os.WriteFile(path, contents, 0644)
+	if err != nil {
+		return fmt.Errorf("Error writing changelog file '%s': %v", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
- Added a flag, `--file` to pass in an existing changelog file that contains an array of changelog entries adhering to the `chlog` format (can also be empty)
- If `--file` flag is passed, the new entry will be added to the top of the changelog file
- Included validation of the file
